### PR TITLE
Fixing PushBullet API issue

### DIFF
--- a/Contents/Code/Session.py
+++ b/Contents/Code/Session.py
@@ -2512,7 +2512,6 @@ def sendPushBullet(title, body, device_iden=""):
     if Prefs['pushbullet_channel']:
         data['channel_tag'] = Prefs['pushbullet_channel']
     values = JSON.StringFromObject(data)
-    #return HTTP.Request(PUSHBULLET_API_URL + "pushes", data=values, headers=api_header)
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
     pushBulletRequest = urllib2.Request(PUSHBULLET_API_URL + "pushes", data=values, headers=api_header)
     return urllib2.urlopen(pushBulletRequest,context=ctx)

--- a/Contents/Code/Session.py
+++ b/Contents/Code/Session.py
@@ -2,7 +2,7 @@
 
 from DumbTools import DumbKeyboard, MESSAGE_OVERLAY_CLIENTS
 
-import re
+import re,urllib2,ssl
 import traceback
 
 # Override Plex L, F functions
@@ -2512,7 +2512,10 @@ def sendPushBullet(title, body, device_iden=""):
     if Prefs['pushbullet_channel']:
         data['channel_tag'] = Prefs['pushbullet_channel']
     values = JSON.StringFromObject(data)
-    return HTTP.Request(PUSHBULLET_API_URL + "pushes", data=values, headers=api_header)
+    #return HTTP.Request(PUSHBULLET_API_URL + "pushes", data=values, headers=api_header)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    pushBulletRequest = urllib2.Request(PUSHBULLET_API_URL + "pushes", data=values, headers=api_header)
+    return urllib2.urlopen(pushBulletRequest,context=ctx)
 
 
 def sendPushover(title, message):


### PR DESCRIPTION
It seems the PushBullet API recently disallowed SSLv3, so we now have to force TLSv1. I didn't know how to do this with Plex's HTTP.Request, so I imported URLlib2 and SSL instead. 